### PR TITLE
fixed name change bug

### DIFF
--- a/PokerNowKit/Models/Game.swift
+++ b/PokerNowKit/Models/Game.swift
@@ -307,6 +307,8 @@ public class Game: NSObject {
 
         if var player = self.players.filter({$0.id == nameIdArray?.last}).first {
 
+            player.name = nameIdArray?.first
+
             self.players.removeAll(where: {$0.id == nameIdArray?.last})
             
             if msg?.contains("quits the game") ?? false {


### PR DESCRIPTION
Addresses Issue #1 player tracking issue.

The Game parsing logic relies on the player ID value when maintaining the list of players. However, there exist cases where a player can leave and rejoin within the same session and change their name. In this case the player's ID remains the same and so the players list will not get updated to reflect the name change. This causes issues when printing the log to PokerStars format.

Added a single line that naively will update the player's name from the value parsed from the line.
